### PR TITLE
Fixed double call on load event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/react-i13n-omniture",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Omniture plugin for react-i13n",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/pagetracker.es6
+++ b/pagetracker.es6
@@ -5,9 +5,6 @@ export default function tracker(Component, config) {
     componentDidMount() {
       this.emitPageView();
     },
-    componentWillReceiveProps() {
-      this.emitPageView();
-    },
     emitPageView() {
       let pageInfo = reactI13n.getRootI13nNode()._model;
       ['title','template','topic','publishDate']


### PR DESCRIPTION
Probably to the switch to the SS rendering it seems that a double request happens when the page load.
Removing the method componentWillReceiveProps seems to fix the issue.