### PR TITLE
fix: add missing babel-eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@economist/doc-pack": "^1.0.6",
     "@economist/provision-react-component": "1.7.7",
     "babel": "^5.8.34",
+    "babel-eslint": "^6.0.2",
     "babel-polyfill": "^6.6.1",
     "babelify": "^6.4.0",
     "browserify": "^13.0.0",


### PR DESCRIPTION
@keithamus There was this missing dependency after provisioning.
Maybe worth a check against PRC.