### PR TITLE
fix: temporary revert to use of global

### DIFF
--- a/src/pagetracker.js
+++ b/src/pagetracker.js
@@ -1,7 +1,4 @@
 import React from 'react';
-/* eslint-disable id-match */
-import Reacti13n from 'react-i13n';
-/* eslint-enable id-match */
 
 export default function tracker(Component, config) {
   const tracked = React.createClass({
@@ -9,9 +6,9 @@ export default function tracker(Component, config) {
       this.emitPageView();
     },
     emitPageView() {
+      /* global reactI13n */
       /* eslint-disable id-match, no-underscore-dangle */
-      const reactI13nInstance = Reacti13n.getInstance();
-      const pageInfo = reactI13nInstance.getRootI13nNode()._model;
+      const pageInfo = reactI13n.getRootI13nNode()._model;
       [ 'title', 'template', 'topic', 'publishDate' ]
       .map((currentValue) => {
         let newProp = {};
@@ -27,7 +24,7 @@ export default function tracker(Component, config) {
         pageInfo[currentValue] = newProp;
         return pageInfo;
       });
-      reactI13nInstance.execute('pageview', pageInfo);
+      reactI13n.execute('pageview', pageInfo);
     },
     render() {
       return <Component {...this.props} />;


### PR DESCRIPTION
I temporary reverting back to the previous version so we have a working no-blocking release that @danielmoll can use.
I will then refactor this and write the right tests to make this code more robust.